### PR TITLE
Introduce select

### DIFF
--- a/sample-app-jsaddle/Elm/List.hs
+++ b/sample-app-jsaddle/Elm/List.hs
@@ -1,0 +1,11 @@
+module Elm.List
+    ( indexedMap
+    ) where
+
+indexedMap :: (Int -> a -> b) -> [a] -> [b]
+indexedMap f xs =
+    let
+        indexedMapHelper _ [] _ = []
+        indexedMapHelper f (x:xs) i = f i x : indexedMapHelper f xs (i+1)
+    in
+    indexedMapHelper f xs 0

--- a/sample-app-jsaddle/Main.hs
+++ b/sample-app-jsaddle/Main.hs
@@ -47,6 +47,8 @@ import Material.Tab as Tab
 import Material.Slider as Slider
 import Material.Menu as Menu
 import Material.FormField as FormField
+import Material.Select as Select
+import Material.Select.Item as SelectItem
 
 (|>) = (Data.Function.&)
 
@@ -59,6 +61,7 @@ data Model
     , tabState :: Int
     , sliderState :: Float
     , menuState :: Bool
+    , selectedItem :: Maybe String
     }
   deriving (Eq)
 
@@ -74,6 +77,7 @@ data Action
   | PressSwitch
   | TabClicked Int
   | SliderChanged Float
+  | ItemSelected String
   | MenuOpened
   | MenuClosed
   deriving (Show, Eq)
@@ -106,7 +110,7 @@ main :: IO ()
 main = runApp $ startApp App {..}
   where
     initialAction = SayHelloWorld -- initial action to be executed on application load
-    model  = Model { counter=0, queue=Snackbar.initialQueue, switchState=False, tabState=0, sliderState=10.0, menuState=False }                    -- initial model
+    model  = Model { counter=0, queue=Snackbar.initialQueue, switchState=False, tabState=0, sliderState=10.0, menuState=False, selectedItem=Just "Third" }                    -- initial model
     update = updateModel          -- update function
     view   = viewModel            -- view function
     events = extendedEvents        -- default delegated events and MDCDialog:close
@@ -121,6 +125,9 @@ updateModel SubtractOne m@Model{counter=counter} = noEff m{counter=counter - 1}
 updateModel NoOp m = noEff m
 updateModel SayHelloWorld m = m <# do
   liftIO (putStrLn "Hello World!") >> pure NoOp
+updateModel (ItemSelected item) m =
+  m{selectedItem=(Just item)} <# do
+    liftIO (putStrLn item) >> pure NoOp
 updateModel (SetActivated item) m@Model{queue=queue} =
   let
     message =
@@ -222,6 +229,8 @@ viewModel m@Model{counter=counter, switchState=switchState, sliderState=sliderSt
       , mySlider m
       , br_ []
       , myMenu m
+      , br_ []
+      , mySelect m
       , br_ []
       , myFormField
       , br_ []
@@ -412,3 +421,20 @@ myFormField =
             |> FormField.setLabel (Just "My checkbox")
         )
         [ MCB.checkbox MCB.config ]
+
+mySelectItem :: String -> SelectItem String Action
+mySelectItem text = SelectItem.selectItem
+    ( SelectItem.config text )
+    [ Miso.text $ Miso.String.toMisoString text ]
+
+mySelect :: Model -> View Action
+mySelect Model{selectedItem=selectedItem} =
+    Select.outlined
+        (Select.setLabel (Just "Choose wisely") $ Select.setOnChange ItemSelected $ Select.setSelected selectedItem Select.config)
+        ( mySelectItem "First" )
+        [ mySelectItem "Second"
+        , mySelectItem "Third"
+        , mySelectItem "Fourth"
+        ]
+
+

--- a/sample-app-jsaddle/Material/Select.hs
+++ b/sample-app-jsaddle/Material/Select.hs
@@ -1,0 +1,394 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Material.Select 
+    ( Config, config
+    , setOnChange
+    , setLabel
+    , setSelected
+    , setDisabled
+    , setRequired
+    , setValid
+    , setLeadingIcon
+    , setAttributes
+    , filled
+    , outlined
+    ) where
+
+import Miso.String
+import Elm.List
+import qualified Miso
+import qualified Miso.Html.Event
+import qualified Material.List as List
+import qualified Material.List.Item as ListItem
+import qualified Material.Menu as Menu
+import qualified Material.Select.Icon as SelectIcon
+import qualified Material.Select.Icon.Internal as SelectIcon
+import qualified Material.Select.Item  (SelectItem)
+import qualified Material.Select.Item.Internal as SelectItem
+import qualified Data.List as List
+import qualified Data.Maybe as Maybe
+import qualified Data.Map as Map
+
+import qualified Data.Function
+
+(|>) = (Data.Function.&)
+
+{-| Configuration of a select
+-}
+data Config a msg
+    = Config
+        { label :: Maybe String
+        , disabled :: Bool
+        , required :: Bool
+        , valid :: Bool
+        , selected :: Maybe a
+        , leadingIcon :: Maybe (SelectIcon.Icon msg)
+        , additionalAttributes :: [Miso.Attribute msg]
+        , onChange :: Maybe (a -> msg)
+        }
+
+
+{-| Default configuration of a select
+-}
+config :: Config a msg
+config =
+    Config
+        { label = Nothing
+        , disabled = False
+        , required = False
+        , valid = True
+        , selected = Nothing
+        , leadingIcon = Nothing
+        , additionalAttributes = []
+        , onChange = Nothing
+        }
+
+
+{-| Specify a select's label
+-}
+setLabel :: Maybe String -> Config a msg -> Config a msg
+setLabel label config_ =
+    config_ { label = label }
+
+
+{-| Specify a select's selected value
+-}
+setSelected :: Maybe a -> Config a msg -> Config a msg
+setSelected selected config_ =
+    config_ { selected = selected }
+
+
+{-| Specify whether a select is disabled
+
+Disabled selects cannot be interacted with an have no visual interaction
+effect.
+
+-}
+setDisabled :: Bool -> Config a msg -> Config a msg
+setDisabled disabled config_ =
+    config_ { disabled = disabled }
+
+
+{-| Specify whether a select is required
+-}
+setRequired :: Bool -> Config a msg -> Config a msg
+setRequired required config_ =
+    config_ { required = required }
+
+
+{-| Specify whether a select is valid
+-}
+setValid :: Bool -> Config a msg -> Config a msg
+setValid valid config_ =
+    config_ { valid = valid }
+
+
+{-| Specify a select's leading icon
+-}
+setLeadingIcon :: Maybe (SelectIcon.Icon msg) -> Config a msg -> Config a msg
+setLeadingIcon leadingIcon config_ =
+    config_ { leadingIcon = leadingIcon }
+
+
+{-| Specify additional attributes
+-}
+setAttributes :: [Miso.Attribute msg] -> Config a msg -> Config a msg
+setAttributes additionalAttributes config_ =
+    config_ { additionalAttributes = additionalAttributes }
+
+
+{-| Specify a message when the user changes the select
+-}
+setOnChange :: (a -> msg) -> Config a msg -> Config a msg
+setOnChange onChange config_ =
+    config_ { onChange = Just onChange }
+
+
+data Variant
+    = Filled
+    | Outlined
+    deriving (Eq)
+
+
+select :: Eq a => Variant -> Config a msg -> SelectItem.SelectItem a msg -> [SelectItem.SelectItem a msg] -> Miso.View msg
+select variant (config_@Config { leadingIcon, selected, additionalAttributes, onChange }) firstSelectItem remainingSelectItems =
+    let
+        selectedIndex =
+            indexedMap
+                (\index (SelectItem.SelectItem (SelectItem.Config { SelectItem.value }) _) ->
+                    if Just value == selected then
+                        Just index
+
+                    else
+                        Nothing
+                )
+                (firstSelectItem : remainingSelectItems)
+                |> List.filter Maybe.isJust
+                |> List.head
+    in
+    Miso.nodeHtml "mdc-select"
+        (Maybe.mapMaybe id
+            [ rootCs
+            , outlinedCs variant
+            , leadingIconCs config_
+            , disabledProp config_
+            , selectedIndexProp selectedIndex
+            , validProp config_
+            , requiredProp config_
+            ]
+            ++ additionalAttributes
+        )
+        [ anchorElt []
+            (Prelude.concat
+                [ [ rippleElt
+                  , leadingIconElt config_
+                  , selectedTextElt
+                  , dropdownIconElt
+                  ]
+                , if variant == Outlined then
+                    [ notchedOutlineElt config_ ]
+
+                  else
+                    [ floatingLabelElt config_
+                    , lineRippleElt
+                    ]
+                ]
+            )
+        , menuElt leadingIcon selected onChange firstSelectItem remainingSelectItems
+        ]
+
+
+{-| Filled select view function
+-}
+filled :: Eq a => Config a msg -> SelectItem.SelectItem a msg -> [SelectItem.SelectItem a msg] -> Miso.View msg
+filled config_ firstSelectItem remainingSelectItems =
+    select Filled config_ firstSelectItem remainingSelectItems
+
+
+{-| Outlined select view function
+-}
+outlined :: Eq a => Config a msg -> SelectItem.SelectItem a msg -> [SelectItem.SelectItem a msg] -> Miso.View msg
+outlined config_ firstSelectItem remainingSelectItems =
+    select Outlined config_ firstSelectItem remainingSelectItems
+
+
+rootCs :: Maybe (Miso.Attribute msg)
+rootCs =
+    Just (Miso.class_ "mdc-select")
+
+
+outlinedCs :: Variant -> Maybe (Miso.Attribute msg)
+outlinedCs variant =
+    if variant == Outlined then
+        Just (Miso.class_ "mdc-select--outlined")
+
+    else
+        Nothing
+
+
+leadingIconCs :: Config a msg -> Maybe (Miso.Attribute msg)
+leadingIconCs (Config { leadingIcon }) =
+    Maybe.maybe Nothing (\_ -> Just $ Miso.class_ "mdc-select--with-leading-icon") leadingIcon
+
+
+disabledProp :: Config a msg -> Maybe (Miso.Attribute msg)
+disabledProp (Config { disabled }) =
+    Just (Miso.boolProp "disabled" disabled)
+
+
+validProp :: Config a msg -> Maybe (Miso.Attribute msg)
+validProp (Config { valid }) =
+    Just (Miso.boolProp "valid" valid)
+
+
+selectedIndexProp :: Maybe Int -> Maybe (Miso.Attribute msg)
+selectedIndexProp selectedIndex =
+    Just
+        (Miso.intProp "selectedIndex"
+            (Maybe.fromMaybe (negate 1) selectedIndex)
+        )
+
+
+requiredProp :: Config a msg -> Maybe (Miso.Attribute msg)
+requiredProp (Config { required }) =
+    Just (Miso.boolProp "required" required)
+
+
+rippleElt :: Miso.View msg
+rippleElt =
+    Miso.span_ [ Miso.class_ "mdc-text-field__ripple" ] []
+
+
+anchorElt :: [Miso.Attribute msg] -> [Miso.View msg] -> Miso.View msg
+anchorElt additionalAttributes nodes =
+    Miso.div_ (Miso.class_ "mdc-select__anchor" : additionalAttributes) nodes
+
+
+leadingIconElt :: Config a msg -> Miso.View msg
+leadingIconElt (Config { leadingIcon }) =
+    case leadingIcon of
+        Nothing ->
+            Miso.text ""
+
+        Just (SelectIcon.Icon { SelectIcon.node, SelectIcon.attributes, SelectIcon.nodes, SelectIcon.onInteraction, SelectIcon.disabled }) ->
+            node
+                (Miso.class_ "mdc-select__icon"
+                    : (case onInteraction of
+                            Just msg ->
+                                if not disabled then
+                                    Miso.intProp "tabindex" 0
+                                        : Miso.stringProp "role" "button"
+                                        : Miso.Html.Event.onClick msg
+                                        {-- : Miso.Html.Event.onKeyDown
+                                            (Miso.Event.Types.KeyCode
+                                                |> Decode.andThen
+                                                    (\keyCode ->
+                                                        if keyCode == 13 then
+                                                            Decode.succeed msg
+
+                                                        else
+                                                            Decode.fail ""
+                                                    )
+                                            ) --}
+                                        : attributes
+
+                                else
+                                    Miso.stringProp "tabindex" "-1"
+                                        : Miso.stringProp "role" "button"
+                                        : attributes
+
+                            Nothing ->
+                                attributes
+                       )
+                )
+                nodes
+
+        {-- Just (SelectIcon.SvgIcon { SelectIcon.node, SelectIcon.attributes, SelectIcon.nodes, SelectIcon.onInteraction, SelectIcon.disabled }) ->
+            node
+                (Miso.Svg.Attributes.class_ "mdc-select__icon"
+                    : (case onInteraction of
+                            Just msg ->
+                                if not disabled then
+                                    Miso.Attributes.tabindex 0
+                                        : Miso.Attributes.attribute "role" "button"
+                                        : Miso.Events.onClick msg
+                                        : Miso.Events.on "keydown"
+                                            (Miso.Events.keyCode
+                                                |> Decode.andThen
+                                                    (\keyCode ->
+                                                        if keyCode == 13 then
+                                                            Decode.succeed msg
+                                                        else
+                                                            Decode.fail ""
+                                                    )
+                                            )
+                                        : attributes
+
+                                else
+                                    Miso.Attributes.tabindex -1
+                                        : Miso.Attributes.attribute "role" "button"
+                                        : attributes
+
+                            Nothing ->
+                                attributes
+                       )
+                )
+                nodes --}
+
+
+dropdownIconElt :: Miso.View msg
+dropdownIconElt =
+    Miso.i_ [ Miso.class_ "mdc-select__dropdown-icon" ] []
+
+
+floatingLabelElt :: Config a msg -> Miso.View msg
+floatingLabelElt (Config { label }) =
+    Miso.div_ [ Miso.class_ "mdc-floating-label" ] [ Miso.text $ toMisoString $ Maybe.fromMaybe "" label ]
+
+
+lineRippleElt :: Miso.View msg
+lineRippleElt =
+    Miso.label_ [ Miso.class_ "mdc-line-ripple" ] []
+
+
+notchedOutlineElt :: Config a msg -> Miso.View msg
+notchedOutlineElt (Config { label }) =
+    Miso.span_ [ Miso.class_ "mdc-notched-outline" ]
+        [ Miso.span_ [ Miso.class_ "mdc-notched-outline__leading" ] []
+        , Miso.span_ [ Miso.class_ "mdc-notched-outline__notch" ]
+            [ Miso.label_ [ Miso.class_ "mdc-floating-label" ]
+                [ Miso.text $ toMisoString (Maybe.fromMaybe "" label) ]
+            ]
+        , Miso.span_ [ Miso.class_ "mdc-notched-outline__trailing" ] []
+        ]
+
+
+menuElt :: Maybe (SelectIcon.Icon msg) -> Maybe a -> Maybe (a -> msg) -> SelectItem.SelectItem a msg -> [SelectItem.SelectItem a msg] -> Miso.View msg
+menuElt leadingIcon selected onChange firstSelectItem remainingSelectItems =
+    Menu.menu
+        (Menu.config
+            |> Menu.setAttributes
+                [ Miso.class_ "mdc-select__menu"
+                , Miso.style_ $ Map.singleton "width" "100%"
+                ]
+        )
+        [ List.list (List.config |> List.setWrapFocus True)
+            (listItem leadingIcon selected onChange firstSelectItem)
+            (Prelude.map (listItem leadingIcon selected onChange) remainingSelectItems)
+        ]
+
+
+listItem :: Maybe (SelectIcon.Icon msg) -> Maybe a -> Maybe (a -> msg) -> SelectItem.SelectItem a msg -> ListItem.ListItem msg
+listItem leadingIcon selected onChange (SelectItem.SelectItem config_ nodes) =
+    ListItem.listItem (listItemConfig selected onChange config_)
+        (if Maybe.isJust leadingIcon then
+            ListItem.graphic [] [] : nodes
+
+         else
+            nodes
+        )
+
+
+listItemConfig :: Maybe a -> Maybe (a -> msg) -> SelectItem.Config a msg -> ListItem.Config msg
+listItemConfig selectedValue onChange (SelectItem.Config { SelectItem.value, SelectItem.disabled, SelectItem.additionalAttributes }) =
+    ListItem.config
+        |> ListItem.setDisabled disabled
+        |> ListItem.setAttributes additionalAttributes
+        |> (case onChange of
+                Just onChange_ ->
+                    ListItem.setOnClick (onChange_ value)
+
+                Nothing ->
+                    id
+           )
+
+
+selectedTextElt :: Miso.View msg
+selectedTextElt =
+    Miso.input_
+        [ Miso.class_ "mdc-select__selected-text"
+        , Miso.boolProp "disabled" True
+        , Miso.boolProp "readonly" True
+        ]
+        

--- a/sample-app-jsaddle/Material/Select/Icon.hs
+++ b/sample-app-jsaddle/Material/Select/Icon.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module Material.Select.Icon 
+    ( Icon, icon
+    , customIcon
+    --, svgIcon
+    , setOnInteraction
+    , setDisabled
+    ) where
+
+import qualified Miso
+import Miso.String
+import Material.Select.Icon.Internal  (Icon(..))
+
+
+{-| Icon type
+-}
+--data alias Icon msg =
+--    Material.Select.Icon.Internal.Icon msg
+
+
+{-| Material Icon
+
+    Select.filled
+        (Select.config
+            |> Select.setLeadingIcon
+                (Just (Select.icon "favorite"))
+        )
+
+-}
+icon :: String -> Icon msg
+icon iconName =
+    customIcon Miso.i_ [ Miso.class_ "material-icons" ] [ Miso.text $ toMisoString iconName ]
+
+
+{-| Custom icon
+
+    Select.raised
+        (Select.config
+            |> Select.setLeadingIcon
+                (Just
+                    (Select.customIcon Miso.i
+                        [ Miso.class_ "fab fa-font-awesome" ]
+                        []
+                    )
+                )
+        )
+
+-}
+customIcon ::
+    ([Miso.Attribute msg] -> [Miso.View msg] -> Miso.View msg)
+    -> [Miso.Attribute msg]
+    -> [Miso.View msg]
+    -> Icon msg
+customIcon node attributes nodes =
+    Icon
+        { node = node
+        , attributes = attributes
+        , nodes = nodes
+        , onInteraction = Nothing
+        , disabled = False
+        }
+
+
+{-| SVG icon
+
+    Select.raised
+        (Select.config
+            |> Select.setLeadingIcon
+                (Just
+                    (Select.svgIcon
+                        [ Svg.Attributes.viewBox "…" ]
+                        [-- …
+                        ]
+                    )
+                )
+        )
+
+-}
+{-- svgIcon :: [Svg.Attribute msg] -> [Svg msg] -> Icon msg
+svgIcon attributes nodes =
+    SvgIcon
+        { node = Svg.svg
+        , attributes = attributes
+        , nodes = nodes
+        , onInteraction = Nothing
+        , disabled = False
+        }
+--}
+
+{-| Specify a message when the user interacts with the icon
+
+    SelectIcon.icon "favorite"
+        |> SelectIcon.setOnInteraction Interacted
+
+-}
+setOnInteraction :: msg -> Icon msg -> Icon msg
+setOnInteraction onInteraction icon_ =
+    case icon_ of
+        icon@Icon{..} ->
+            icon { onInteraction = onInteraction }
+
+        {-- SvgIcon svgIcon ->
+            SvgIcon svgIcon { onInteraction = Just onInteraction } --}
+
+
+{-| Specify an icon to be disabled
+
+Disabled icons cannot be interacted with and have no visual interaction
+effect.
+
+    SelectIcon.icon "favorite"
+        |> SelectIcon.setDisabled True
+
+-}
+setDisabled :: Bool -> Icon msg -> Icon msg
+setDisabled disabled icon_ =
+    case icon_ of
+        icon@Icon{..} ->
+            icon { disabled = disabled }
+
+        {-- SvgIcon svgIcon ->
+            SvgIcon svgIcon { disabled = disabled } --}

--- a/sample-app-jsaddle/Material/Select/Icon/Internal.hs
+++ b/sample-app-jsaddle/Material/Select/Icon/Internal.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Material.Select.Icon.Internal
+  where
+
+import qualified Miso
+
+data Icon msg
+    = Icon
+        { node :: [Miso.Attribute msg] -> [Miso.View msg] -> Miso.View msg
+        , attributes :: [Miso.Attribute msg]
+        , nodes :: [Miso.View msg]
+        , onInteraction :: Maybe msg
+        , disabled :: Bool
+        }
+    {-- | SvgIcon
+        { node :: [Svg.Attribute msg] -> [Svg msg] -> Miso.View msg
+        , attributes :: [Svg.Attribute msg]
+        , nodes :: [Svg msg]
+        , onInteraction :: Maybe msg
+        , disabled :: Bool
+        } --}

--- a/sample-app-jsaddle/Material/Select/Item.hs
+++ b/sample-app-jsaddle/Material/Select/Item.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns #-}
+module Material.Select.Item 
+    ( Config, config
+    , InitialConfig
+    , setDisabled
+    , setAttributes
+    , SelectItem, selectItem
+    ) where
+
+import qualified Miso
+import Material.Select.Item.Internal  (Config(..), SelectItem(..))
+
+
+{-| Configuration of a select item
+-}
+--data Config a msg =
+--    Material.Select.Item.Internal.Config a msg
+
+data InitialConfig a = InitialConfig
+    { value :: a }
+
+{-| Default configuration of a select item
+-}
+config :: a -> Config a msg
+config value =
+    Config
+        { Material.Select.Item.Internal.value = value
+        , disabled = False
+        , additionalAttributes = []
+        }
+
+
+{-| Specify whether a select item should be disabled
+
+Disabled select items cannot be interacted with and have not visual interaction
+effect.
+
+-}
+setDisabled :: Bool -> Config a msg -> Config a msg
+setDisabled disabled config_ =
+    config_ { disabled = disabled }
+
+
+{-| Specify additional attributes
+-}
+setAttributes :: [Miso.Attribute msg] -> Config a msg -> Config a msg
+setAttributes additionalAttributes config_ =
+    config_ { additionalAttributes = additionalAttributes }
+
+
+{-| Select item type
+-}
+--data SelectItem a msg =
+--    Material.Select.Item.Internal.SelectItem a msg
+
+
+{-| Select item constructor
+-}
+selectItem :: Config a msg -> [Miso.View msg] -> SelectItem a msg
+selectItem =
+    SelectItem

--- a/sample-app-jsaddle/Material/Select/Item/Internal.hs
+++ b/sample-app-jsaddle/Material/Select/Item/Internal.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Material.Select.Item.Internal
+  where
+
+import qualified Miso
+
+data Config a msg
+    = Config
+        { value :: a
+        , disabled :: Bool
+        , additionalAttributes :: [Miso.Attribute msg]
+        }
+
+
+data SelectItem a msg
+    = SelectItem (Config a msg) ([Miso.View msg])


### PR DESCRIPTION
**Why:**

Select is part of the original Elm library.

**What:**

Introducing the Select component without:
  - Svg support;
  - Keyboard support;

**Testing:**


https://user-images.githubusercontent.com/329541/103247081-ee17e500-4965-11eb-9a45-9a3b7e345742.mp4

