### PR TITLE
Add filled style to TextField

### DIFF
--- a/sample-app-jsaddle/Main.hs
+++ b/sample-app-jsaddle/Main.hs
@@ -265,7 +265,7 @@ viewModel m@Model {counter = counter, switchState = switchState, sliderState = s
               br_ [],
               Switch.switch (Switch.setOnChange PressSwitch $ Switch.setChecked switchState $ Switch.config),
               br_ [],
-              MTF.outlined (MTF.setLabel (Just "Hi") $ MTF.config),
+              MTF.filled (MTF.setLabel (Just "Hi") $ MTF.config),
               br_ [],
               activatedItemList m,
               br_ [],

--- a/sample-app-jsaddle/Material/TextField.hs
+++ b/sample-app-jsaddle/Material/TextField.hs
@@ -204,6 +204,7 @@ textField outlined_ (config_@Config {additionalAttributes = additionalAttributes
         id
         [ rootCs,
           noLabelCs config_,
+          filledCs outlined_,
           outlinedCs outlined_,
           fullwidthCs config_,
           disabledCs config_,
@@ -258,6 +259,12 @@ icon additionalAttributes iconName =
 rootCs :: Maybe (Miso.Attribute msg)
 rootCs =
   Just (Miso.class_ "mdc-text-field")
+
+filledCs :: Bool -> Maybe (Miso.Attribute msg)
+filledCs outlined_ =
+  if not outlined_
+    then Just (Miso.class_ "mdc-text-field--filled")
+    else Nothing
 
 outlinedCs :: Bool -> Maybe (Miso.Attribute msg)
 outlinedCs outlined_ =


### PR DESCRIPTION
**Why:**

Adressing #2 

**What:**

Added missing CSS for filled style TextField

**Testing:**

|Before|After| 
|---|---|
|![test](https://user-images.githubusercontent.com/34752929/111395627-9ca60900-86bd-11eb-99ae-44163b7a7794.gif)|![test2](https://user-images.githubusercontent.com/34752929/111395696-ba736e00-86bd-11eb-8c3d-b93ad0175467.gif)|
