### PR TITLE
Use normal value in Decoder

### DIFF
--- a/sample-app-jsaddle/Material/Slider.hs
+++ b/sample-app-jsaddle/Material/Slider.hs
@@ -205,8 +205,8 @@ ariaValuenowAttr (Config {value = value}) =
 valueDecoder :: Miso.Decoder Float
 valueDecoder =
   Miso.Decoder
-    { Miso.decodeAt = Miso.DecodeTarget ["target", "slider_", "foundation_"],
-      Miso.decoder = withObject "foundation_" $ \o -> o .: "value_"
+    { Miso.decodeAt = Miso.DecodeTarget ["target"],
+      Miso.decoder = withObject "target" $ \o -> o .: "value"
     }
 
 changeHandler :: Config msg -> Maybe (Miso.Attribute msg)


### PR DESCRIPTION
**Why:**

As mentioned in #22 the current method of getting the slider value is slow and not type safe leading to stutter and crashes.

**What:**

This change uses the normal `target.value` again and depends on https://github.com/dmjio/miso/pull/647#issue-595112031.

**Testing:**

|Before|![image](https://user-images.githubusercontent.com/34752929/111552298-4cdd4580-8782-11eb-99b5-946c7f4b78d8.png)| 
|---|---|
|After|![image](https://user-images.githubusercontent.com/34752929/111552479-b6f5ea80-8782-11eb-8bf5-b33b7c010499.png)|
